### PR TITLE
Support for automatic type inferrence

### DIFF
--- a/lib/shared_settings.ex
+++ b/lib/shared_settings.ex
@@ -16,7 +16,6 @@ defmodule SharedSettings do
   @store Config.storage_adapter()
 
   @type setting_name :: atom() | String.t()
-  @type setting_type :: atom() | String.t()
 
   @doc ~S"""
   Creates or updates a setting.
@@ -26,32 +25,31 @@ defmodule SharedSettings do
   ## Arguments
 
   * `name` - An atom or string representing the name of the setting. Used for fetching/deleting
-  * `type` - An atom or string of either `string`, `number`, `boolean`, or `range` that specifies the expected value
-  * `value` - Any data with the type specified by `type`
+  * `value` - Any data of type string, number, boolean, or range
 
   ## Returns
 
   If a setting is successfully stored, a tuple of `:ok` and the setting name as a string is returned.
 
-  If a `value` is specified that doesn't match the `type`, a tuple of `{:error, :incompatible_type}` is returned.
+  If `value`'s type isn't supported, {:error, :unsupported_type} is returned
 
   Any other failures (say, from the storage adaptor) will be returned as-is.
   Failures to write to cache will not be returned as an error so long as writing to storage succeeds.
   """
-  @spec put(setting_name(), setting_type(), any()) :: {:ok, String.t()} | {:error, any()}
-  def put(name, type, value) when is_atom(name) do
+  @spec put(setting_name(), any()) :: {:ok, String.t()} | {:error, any()}
+  def put(name, value) when is_atom(name) do
     setting_result =
       name
       |> Atom.to_string()
-      |> Setting.build_setting(type, value)
+      |> Setting.build_setting(value)
 
     do_put(setting_result)
   end
 
-  def put(name, type, value) when is_binary(name) do
+  def put(name, value) when is_binary(name) do
     setting_result =
       name
-      |> Setting.build_setting(type, value)
+      |> Setting.build_setting(value)
 
     do_put(setting_result)
   end

--- a/lib/shared_settings/store.ex
+++ b/lib/shared_settings/store.ex
@@ -12,7 +12,7 @@ defmodule SharedSettings.Store do
   number: "1234"
   string: "any string"
   boolean: "1" or "0"
-  range: "low,high". eg: "1,5"
+  range: "low,high". eg: "1,5" *inclusive*
   """
 
   alias SharedSettings.Setting

--- a/test/shared_settings/setting_test.exs
+++ b/test/shared_settings/setting_test.exs
@@ -13,80 +13,68 @@ defmodule SharedSettings.SettingTest do
     {:ok, name: name}
   end
 
-  describe "build_setting/3" do
+  describe "build_setting/2" do
     test "string values are created as expected", %{name: name} do
-      {:ok, setting} = Setting.build_setting(name, :string, "test_string")
+      {:ok, setting} = Setting.build_setting(name, "test_string")
 
       assert setting == %Setting{name: name, type: "string", value: "test_string"}
     end
 
-    test "non-string values error if string is expected", %{name: name} do
-      {:error, :incompatible_type} = Setting.build_setting(name, :string, 123)
-    end
-
     test "number values are converted to strings", %{name: name} do
-      {:ok, setting} = Setting.build_setting(name, :number, 123)
+      {:ok, setting} = Setting.build_setting(name, 123)
 
       assert setting == %Setting{name: name, type: "number", value: "123"}
     end
 
     test "number type supports floats", %{name: name} do
-      {:ok, setting} = Setting.build_setting(name, :number, 12.3)
+      {:ok, setting} = Setting.build_setting(name, 12.3)
 
       assert setting == %Setting{name: name, type: "number", value: "12.3"}
     end
 
     test "number type supports negative numbers", %{name: name} do
-      {:ok, setting} = Setting.build_setting(name, :number, -123)
+      {:ok, setting} = Setting.build_setting(name, -123)
 
       assert setting == %Setting{name: name, type: "number", value: "-123"}
     end
 
-    test "non-number values error if number is expected", %{name: name} do
-      {:error, :incompatible_type} = Setting.build_setting(name, :number, "str")
-    end
-
     test "boolean values are converted to strings", %{name: name} do
-      {:ok, true_setting} = Setting.build_setting(name, :boolean, true)
-      {:ok, false_setting} = Setting.build_setting(name, :boolean, false)
+      {:ok, true_setting} = Setting.build_setting(name, true)
+      {:ok, false_setting} = Setting.build_setting(name, false)
 
       assert true_setting == %Setting{name: name, type: "boolean", value: "1"}
       assert false_setting == %Setting{name: name, type: "boolean", value: "0"}
     end
 
-    test "non-boolean values error if boolean is expected", %{name: name} do
-      {:error, :incompatible_type} = Setting.build_setting(name, :boolean, "str")
-    end
-
     test "range values are converted to strings", %{name: name} do
-      {:ok, setting} = Setting.build_setting(name, :range, 2..4)
+      {:ok, setting} = Setting.build_setting(name, 2..4)
 
       assert setting == %Setting{name: name, type: "range", value: "2,4"}
     end
 
-    test "non-range values error if range is expected", %{name: name} do
-      {:error, :incompatible_type} = Setting.build_setting(name, :range, "str")
+    test "strings are supported for type names" do
+      assert {:ok, _} = Setting.build_setting(random_string(), "test_string")
+      assert {:ok, _} = Setting.build_setting(random_string(), 123)
+      assert {:ok, _} = Setting.build_setting(random_string(), true)
+      assert {:ok, _} = Setting.build_setting(random_string(), 1..5)
     end
 
-    test "strings are supported for type names" do
-      assert {:ok, _} = Setting.build_setting(random_string(), "string", "test_string")
-      assert {:ok, _} = Setting.build_setting(random_string(), "number", 123)
-      assert {:ok, _} = Setting.build_setting(random_string(), "boolean", true)
-      assert {:ok, _} = Setting.build_setting(random_string(), "range", 1..5)
+    test "returns an error if type isn't supported" do
+      assert {:error, :unsupported_type} = Setting.build_setting(random_string(), nil)
     end
   end
 
   describe "restore_value/1" do
     test "restores string values", %{name: name} do
-      {:ok, setting} = Setting.build_setting(name, :string, "asdf")
+      {:ok, setting} = Setting.build_setting(name, "asdf")
 
       assert {:ok, "asdf"} = Setting.restore_value(setting)
     end
 
     test "restores number values", %{name: name} do
-      {:ok, number} = Setting.build_setting(name, :number, 123)
-      {:ok, neg_number} = Setting.build_setting(name, :number, -123)
-      {:ok, float} = Setting.build_setting(name, :number, 12.3)
+      {:ok, number} = Setting.build_setting(name, 123)
+      {:ok, neg_number} = Setting.build_setting(name, -123)
+      {:ok, float} = Setting.build_setting(name, 12.3)
 
       assert {:ok, 123} = Setting.restore_value(number)
       assert {:ok, -123} = Setting.restore_value(neg_number)
@@ -94,15 +82,15 @@ defmodule SharedSettings.SettingTest do
     end
 
     test "restores boolean values", %{name: name} do
-      {:ok, true_setting} = Setting.build_setting(name, :boolean, true)
-      {:ok, false_setting} = Setting.build_setting(name, :boolean, false)
+      {:ok, true_setting} = Setting.build_setting(name, true)
+      {:ok, false_setting} = Setting.build_setting(name, false)
 
       assert {:ok, true} = Setting.restore_value(true_setting)
       assert {:ok, false} = Setting.restore_value(false_setting)
     end
 
     test "restores range values", %{name: name} do
-      {:ok, setting} = Setting.build_setting(name, :range, 2..4)
+      {:ok, setting} = Setting.build_setting(name, 2..4)
 
       assert {:ok, 2..4} = Setting.restore_value(setting)
     end

--- a/test/shared_settings_test.exs
+++ b/test/shared_settings_test.exs
@@ -15,11 +15,11 @@ defmodule SharedSettingsTest do
     :ok
   end
 
-  describe "put/3" do
+  describe "put/2" do
     test "values are stored in cache" do
       name = unique_atom()
 
-      {:ok, key} = SharedSettings.put(name, :string, "asdf")
+      {:ok, key} = SharedSettings.put(name, "asdf")
 
       assert {:ok, %Setting{name: key, type: "string", value: "asdf"}} = EtsStore.get(key)
     end
@@ -27,7 +27,7 @@ defmodule SharedSettingsTest do
     test "values are stored in persistence" do
       name = unique_atom()
 
-      {:ok, key} = SharedSettings.put(name, :string, "asdf")
+      {:ok, key} = SharedSettings.put(name, "asdf")
 
       assert {:ok, %Setting{name: key, type: "string", value: "asdf"}} = Redis.get(key)
     end
@@ -36,17 +36,17 @@ defmodule SharedSettingsTest do
       string_name = random_string()
       name = String.to_atom(string_name)
 
-      assert {:ok, ^string_name} = SharedSettings.put(name, :string, "asdf")
+      assert {:ok, ^string_name} = SharedSettings.put(name, "asdf")
     end
 
     test "failure returns {:error, any()}" do
       name = unique_atom()
 
-      assert {:error, :incompatible_type} = SharedSettings.put(name, :string, 123)
+      assert {:error, :unsupported_type} = SharedSettings.put(name, nil)
     end
 
     test "strings are supported for setting names and types" do
-      {:ok, string_name} = SharedSettings.put(random_string(), "string", "asdf")
+      {:ok, string_name} = SharedSettings.put(random_string(), "asdf")
 
       assert {:ok, "asdf"} = SharedSettings.get(string_name)
     end
@@ -56,7 +56,7 @@ defmodule SharedSettingsTest do
     test "values are retrieved" do
       name = unique_atom()
 
-      SharedSettings.put(name, :string, "asdf")
+      SharedSettings.put(name, "asdf")
 
       assert {:ok, "asdf"} = SharedSettings.get(name)
     end
@@ -104,7 +104,7 @@ defmodule SharedSettingsTest do
     end
 
     test "string names are supported for fetching settings" do
-      {:ok, string_name} = SharedSettings.put(unique_atom(), "string", "asdf")
+      {:ok, string_name} = SharedSettings.put(unique_atom(), "asdf")
 
       assert {:ok, "asdf"} = SharedSettings.get(string_name)
     end
@@ -144,7 +144,7 @@ defmodule SharedSettingsTest do
     end
 
     test "string names are supported for deleting settings" do
-      {:ok, string_name} = SharedSettings.put(unique_atom(), "string", "asdf")
+      {:ok, string_name} = SharedSettings.put(unique_atom(), "asdf")
 
       :ok = SharedSettings.delete(string_name)
 
@@ -156,7 +156,7 @@ defmodule SharedSettingsTest do
     test "returns true when a setting exists" do
       name = unique_atom()
 
-      SharedSettings.put(name, :string, "asdf")
+      SharedSettings.put(name, "asdf")
 
       assert true == SharedSettings.exists?(name)
     end
@@ -170,7 +170,7 @@ defmodule SharedSettingsTest do
     test "string names are supported" do
       name = random_string()
 
-      SharedSettings.put(name, :string, "asdf")
+      SharedSettings.put(name, "asdf")
 
       assert true == SharedSettings.exists?(name)
     end


### PR DESCRIPTION
We already have the guards in place for type validation, why not instead use that to infer the type from a given value.

Now, you only need to specify a name and a value (of supported type) and the rest is handled for you